### PR TITLE
Fix password text input

### DIFF
--- a/src/routes/CreatePendingEvent.js
+++ b/src/routes/CreatePendingEvent.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import styled from 'react-emotion'
 import { withRouter } from 'react-router-dom'
+import TextInput from '../components/Forms/TextInput'
+import Label from '../components/Forms/Label'
 
 import PartyForm from '../components/SingleEvent/Admin/PartyForm'
 import { CREATE_PENDING_PARTY } from '../graphql/mutations'
@@ -26,14 +28,12 @@ class Create extends Component {
           mutation={CREATE_PENDING_PARTY}
           variables={{ password }}
         >
-          <p>
-            <label>SECRET PASSWORD:</label>
-            <input
-              value={password}
-              onChangeText={val => this.setState({ password: val })}
-              type="password"
-            />
-          </p>
+          <Label>SECRET PASSWORD:</Label>
+          <TextInput
+            value={password}
+            onChangeText={val => this.setState({ password: val })}
+            type="password"
+          />
         </PartyForm>
       </CreateContainer>
     )


### PR DESCRIPTION
For some reason, normal `<input>` wasn't allowing users to type password (nor even as a text). Using our component somehow fixed.