### PR TITLE
Add blocknative assist

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "apollo-link-state": "^0.4.1",
     "apollo-upload-client": "^10.0.0",
     "apollo-utilities": "^1.0.21",
+    "bnc-assist": "^0.4.0",
     "decimal.js": "^10.0.1",
     "emotion": "^9.2.6",
     "es6-promisify": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "apollo-link-state": "^0.4.1",
     "apollo-upload-client": "^10.0.0",
     "apollo-utilities": "^1.0.21",
-    "bnc-assist": "^0.4.0",
+    "bnc-assist": "^0.5.0",
     "decimal.js": "^10.0.1",
     "emotion": "^9.2.6",
     "es6-promisify": "^6.0.0",

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -37,14 +37,14 @@ if (argv.ropsten) {
   appConfig.GIT_COMMIT = getGitCommit()
   appConfig.LOGROCKET_TOKEN = '5gnafo/kickback-ropsten'
   appConfig.ROLLBAR_TOKEN = '37e0bca9006a4a348e244ae2d233d660'
-  appConfig.BLOCKNATIVE_DAPPID = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
+  appConfig.BLOCKNATIVE_DAPPID = '18cb2fa0-5941-43a2-b71d-07221c15a50f'
 } else if (argv.rinkeby) {
   appConfig.ENV = 'rinkeby'
   appConfig.API_URL = 'https://rinkeby.api.kickback.events'
   appConfig.GIT_COMMIT = getGitCommit()
   appConfig.LOGROCKET_TOKEN = '5gnafo/kickback-rinkeby'
   appConfig.ROLLBAR_TOKEN = 'e676d64e462b48d098a12db8a173598a'
-  appConfig.BLOCKNATIVE_DAPPID = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
+  appConfig.BLOCKNATIVE_DAPPID = '27b3eac2-e46c-428a-9a0c-56cce2725d42'
   appConfig.MIXPANEL_ID = '28243587317e7b2d8a669dcce23302cb'
 } else if (argv.live) {
   appConfig.ENV = 'live'
@@ -53,7 +53,7 @@ if (argv.ropsten) {
   appConfig.MIXPANEL_ID = '11a2f7a59470cdb46cb611c5d22876f2'
   appConfig.LOGROCKET_TOKEN = '5gnafo/kickback-live'
   appConfig.ROLLBAR_TOKEN = 'bfb8dfff7ff44f6fa6a13d4571447c28'
-  appConfig.BLOCKNATIVE_DAPPID = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
+  appConfig.BLOCKNATIVE_DAPPID = '612ef703-3041-442c-b246-cf68604b8ce9'
 }
 
 const str = JSON.stringify(appConfig, null, 2)

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -37,12 +37,14 @@ if (argv.ropsten) {
   appConfig.GIT_COMMIT = getGitCommit()
   appConfig.LOGROCKET_TOKEN = '5gnafo/kickback-ropsten'
   appConfig.ROLLBAR_TOKEN = '37e0bca9006a4a348e244ae2d233d660'
+  appConfig.BLOCKNATIVE_DAPPID = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
 } else if (argv.rinkeby) {
   appConfig.ENV = 'rinkeby'
   appConfig.API_URL = 'https://rinkeby.api.kickback.events'
   appConfig.GIT_COMMIT = getGitCommit()
   appConfig.LOGROCKET_TOKEN = '5gnafo/kickback-rinkeby'
   appConfig.ROLLBAR_TOKEN = 'e676d64e462b48d098a12db8a173598a'
+  appConfig.BLOCKNATIVE_DAPPID = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
 } else if (argv.live) {
   appConfig.ENV = 'live'
   appConfig.API_URL = 'https://live.api.kickback.events'
@@ -50,6 +52,7 @@ if (argv.ropsten) {
   appConfig.MIXPANEL_ID = '11a2f7a59470cdb46cb611c5d22876f2'
   appConfig.LOGROCKET_TOKEN = '5gnafo/kickback-live'
   appConfig.ROLLBAR_TOKEN = 'bfb8dfff7ff44f6fa6a13d4571447c28'
+  appConfig.BLOCKNATIVE_DAPPID = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
 }
 
 const str = JSON.stringify(appConfig, null, 2)

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -45,6 +45,7 @@ if (argv.ropsten) {
   appConfig.LOGROCKET_TOKEN = '5gnafo/kickback-rinkeby'
   appConfig.ROLLBAR_TOKEN = 'e676d64e462b48d098a12db8a173598a'
   appConfig.BLOCKNATIVE_DAPPID = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
+  appConfig.MIXPANEL_ID = '28243587317e7b2d8a669dcce23302cb'
 } else if (argv.live) {
   appConfig.ENV = 'live'
   appConfig.API_URL = 'https://live.api.kickback.events'

--- a/src/api/analytics.js
+++ b/src/api/analytics.js
@@ -6,8 +6,8 @@ export const setup = () => {
   }
 }
 
-export const track = event => {
+export const track = (event, props) => {
   if (MIXPANEL_ID) {
-    window.mixpanel.track(event)
+    window.mixpanel.track(event, props)
   }
 }

--- a/src/api/analytics.js
+++ b/src/api/analytics.js
@@ -1,4 +1,5 @@
 import { MIXPANEL_ID } from '../config'
+
 export const setup = () => {
   if (MIXPANEL_ID && window.mixpanel) {
     window.mixpanel.init(MIXPANEL_ID)

--- a/src/api/analytics.js
+++ b/src/api/analytics.js
@@ -1,5 +1,4 @@
 import { MIXPANEL_ID } from '../config'
-console.log({ MIXPANEL_ID })
 export const setup = () => {
   if (MIXPANEL_ID && window.mixpanel) {
     window.mixpanel.init(MIXPANEL_ID)

--- a/src/api/analytics.js
+++ b/src/api/analytics.js
@@ -1,5 +1,5 @@
 import { MIXPANEL_ID } from '../config'
-
+console.log({ MIXPANEL_ID })
 export const setup = () => {
   if (MIXPANEL_ID && window.mixpanel) {
     window.mixpanel.init(MIXPANEL_ID)

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -64,7 +64,7 @@ async function getWeb3() {
   if (!web3) {
     console.log('getWeb32')
     try {
-      networkState = {}
+      networkState = { allGood: true }
       console.log('getWeb33')
       const result = await clientInstance.query({
         query: NETWORK_ID_QUERY
@@ -128,14 +128,13 @@ async function getWeb3() {
       if (networkState.networkId !== networkState.expectedNetworkId) {
         console.log('getWeb375')
         networkState.wrongNetwork = true
-        web3 = null
+        networkState.allGood = false
       }
       console.log('getWeb376')
       // if web3 not set then something failed
       if (!web3) {
+        networkState.allGood = false
         throw new Error('Error setting up web3')
-      } else {
-        networkState.allGood = true
       }
 
       // poll for blocks

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -60,10 +60,12 @@ const isLocalNetwork = id => {
 }
 
 async function getWeb3() {
+  console.log('getWeb31')
   if (!web3) {
+    console.log('getWeb32')
     try {
       networkState = {}
-
+      console.log('getWeb33')
       const result = await clientInstance.query({
         query: NETWORK_ID_QUERY
       })
@@ -71,17 +73,22 @@ async function getWeb3() {
       if (result.error) {
         throw new Error(result.error)
       }
-
+      console.log('getWeb34')
       networkState.expectedNetworkId = result.data.networkId
       networkState.expectedNetworkName = getNetworkName(
         networkState.expectedNetworkId
       )
+      console.log('getWeb35')
       if (window.ethereum) {
+        console.log('getWeb36')
         web3 = new Web3(window.ethereum)
+        console.log('getWeb37')
       } else if (window.web3 && window.web3.currentProvider) {
+        console.log('getWeb38')
         web3 = new Web3(window.web3.currentProvider)
         networkState.readOnly = false
       } else {
+        console.log('getWeb39')
         //local node
         const url = 'http://localhost:8545'
 
@@ -109,17 +116,21 @@ async function getWeb3() {
             console.log('Success: Cloud node active')
           }
         }
+        console.log('getWeb310')
       }
-
+      console.log('getWeb371', web3)
       networkState.networkId = `${await web3.eth.net.getId()}`
+      console.log('getWeb372')
       networkState.networkName = getNetworkName(networkState.networkId)
+      console.log('getWeb373')
       networkState.isLocalNetwork = isLocalNetwork(networkState.networkId)
-
+      console.log('getWeb374')
       if (networkState.networkId !== networkState.expectedNetworkId) {
+        console.log('getWeb375')
         networkState.wrongNetwork = true
         web3 = null
       }
-
+      console.log('getWeb376')
       // if web3 not set then something failed
       if (!web3) {
         throw new Error('Error setting up web3')

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -199,7 +199,7 @@ export async function getAccount() {
       return accounts[accountIndex]
     } else {
       try {
-        const accounts = await window.ethereum.enable()
+        const accounts = await window.ethereum.send('eth_requestAccounts')
         return accounts[accountIndex]
       } catch (error) {
         console.warn('Did not allow app to access dapp browser')

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -60,12 +60,9 @@ const isLocalNetwork = id => {
 }
 
 async function getWeb3() {
-  console.log('getWeb31')
   if (!web3) {
-    console.log('getWeb32')
     try {
       networkState = { allGood: true }
-      console.log('getWeb33')
       const result = await clientInstance.query({
         query: NETWORK_ID_QUERY
       })
@@ -73,22 +70,16 @@ async function getWeb3() {
       if (result.error) {
         throw new Error(result.error)
       }
-      console.log('getWeb34')
       networkState.expectedNetworkId = result.data.networkId
       networkState.expectedNetworkName = getNetworkName(
         networkState.expectedNetworkId
       )
-      console.log('getWeb35')
       if (window.ethereum) {
-        console.log('getWeb36')
         web3 = new Web3(window.ethereum)
-        console.log('getWeb37')
       } else if (window.web3 && window.web3.currentProvider) {
-        console.log('getWeb38')
         web3 = new Web3(window.web3.currentProvider)
         networkState.readOnly = false
       } else {
-        console.log('getWeb39')
         //local node
         const url = 'http://localhost:8545'
 
@@ -116,21 +107,14 @@ async function getWeb3() {
             console.log('Success: Cloud node active')
           }
         }
-        console.log('getWeb310')
       }
-      console.log('getWeb371', web3)
       networkState.networkId = `${await web3.eth.net.getId()}`
-      console.log('getWeb372')
       networkState.networkName = getNetworkName(networkState.networkId)
-      console.log('getWeb373')
       networkState.isLocalNetwork = isLocalNetwork(networkState.networkId)
-      console.log('getWeb374')
       if (networkState.networkId !== networkState.expectedNetworkId) {
-        console.log('getWeb375')
         networkState.wrongNetwork = true
         networkState.allGood = false
       }
-      console.log('getWeb376')
       // if web3 not set then something failed
       if (!web3) {
         networkState.allGood = false

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -274,9 +274,12 @@ export class ChainMutationButton extends Component {
             notReadyError: CANNOT_RESOLVE_CORRECT_NETWORK
           })
         }
-      }
-      if (!assist.error) {
+        // Do not check assist.error as blocknative may incorrectly detect as error
         postMutation()
+      } else {
+        if (!assist.error) {
+          postMutation()
+        }
       }
     })
   }

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Mutation } from 'react-apollo'
+
 import {
   CANNOT_RESOLVE_ACCOUNT_ADDRESS,
   CANNOT_RESOLVE_CORRECT_NETWORK
@@ -269,6 +270,7 @@ export class ChainMutationButton extends Component {
           })
         }
       }
+
       postMutation()
     })
   }

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -260,7 +260,7 @@ export class ChainMutationButton extends Component {
         expectedNetworkId: networkState.expectedNetworkId,
         action
       })
-      if (assist.mobile) {
+      if (assist.mobileDevice) {
         if (!address) {
           return this.setState({
             notReadyError: CANNOT_RESOLVE_ACCOUNT_ADDRESS

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -2,6 +2,10 @@ import _ from 'lodash'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Mutation } from 'react-apollo'
+import {
+  CANNOT_RESOLVE_ACCOUNT_ADDRESS,
+  CANNOT_RESOLVE_CORRECT_NETWORK
+} from '../utils/errors'
 import Assist from './Header/Assist'
 import { events, getTransactionReceipt } from '../api/web3'
 import { GlobalConsumer } from '../GlobalState'
@@ -251,7 +255,20 @@ export class ChainMutationButton extends Component {
   _onClick = ({ networkState, reloadUserAddress, postMutation }) => {
     this.setState({ notReadyError: null }, async () => {
       const address = await reloadUserAddress()
-      Assist({ expectedNetworkId: networkState.expectedNetworkId })
+      let assist = Assist({ expectedNetworkId: networkState.expectedNetworkId })
+      if (assist.mobile) {
+        if (!address) {
+          return this.setState({
+            notReadyError: CANNOT_RESOLVE_ACCOUNT_ADDRESS
+          })
+        }
+
+        if (!networkState.allGood) {
+          return this.setState({
+            notReadyError: CANNOT_RESOLVE_CORRECT_NETWORK
+          })
+        }
+      }
       postMutation()
     })
   }

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -2,11 +2,7 @@ import _ from 'lodash'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Mutation } from 'react-apollo'
-
-import {
-  CANNOT_RESOLVE_ACCOUNT_ADDRESS,
-  CANNOT_RESOLVE_CORRECT_NETWORK
-} from '../utils/errors'
+import Assist from './Header/Assist'
 import { events, getTransactionReceipt } from '../api/web3'
 import { GlobalConsumer } from '../GlobalState'
 import SafeQuery from './SafeQuery'
@@ -255,19 +251,7 @@ export class ChainMutationButton extends Component {
   _onClick = ({ networkState, reloadUserAddress, postMutation }) => {
     this.setState({ notReadyError: null }, async () => {
       const address = await reloadUserAddress()
-
-      if (!address) {
-        return this.setState({
-          notReadyError: CANNOT_RESOLVE_ACCOUNT_ADDRESS
-        })
-      }
-
-      if (!networkState.allGood) {
-        return this.setState({
-          notReadyError: CANNOT_RESOLVE_CORRECT_NETWORK
-        })
-      }
-
+      Assist({ expectedNetworkId: networkState.expectedNetworkId })
       postMutation()
     })
   }

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -275,6 +275,7 @@ export class ChainMutationButton extends Component {
           })
         }
       }
+
       postMutation()
     })
   }

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -275,8 +275,9 @@ export class ChainMutationButton extends Component {
           })
         }
       }
-
-      postMutation()
+      if (!assist.error) {
+        postMutation()
+      }
     })
   }
 }

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -223,6 +223,7 @@ export class ChainMutationButton extends Component {
       notReadyError ||
       tooltip ||
       'Please sign the created transaction using your wallet or Dapp browser'
+
     return (
       <GlobalConsumer>
         {({ networkState, reloadUserAddress }) => (
@@ -256,7 +257,8 @@ export class ChainMutationButton extends Component {
   _onClick = ({ networkState, reloadUserAddress, postMutation, action }) => {
     this.setState({ notReadyError: null }, async () => {
       const address = await reloadUserAddress()
-      let assist = Assist({
+
+      let assist = await Assist({
         expectedNetworkId: networkState.expectedNetworkId,
         action
       })
@@ -273,7 +275,6 @@ export class ChainMutationButton extends Component {
           })
         }
       }
-
       postMutation()
     })
   }

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -262,7 +262,7 @@ export class ChainMutationButton extends Component {
         expectedNetworkId: networkState.expectedNetworkId,
         action
       })
-      if (assist.mobileDevice) {
+      if (assist.fallback) {
         if (!address) {
           return this.setState({
             notReadyError: CANNOT_RESOLVE_ACCOUNT_ADDRESS

--- a/src/components/ChainMutation.js
+++ b/src/components/ChainMutation.js
@@ -223,7 +223,6 @@ export class ChainMutationButton extends Component {
       notReadyError ||
       tooltip ||
       'Please sign the created transaction using your wallet or Dapp browser'
-
     return (
       <GlobalConsumer>
         {({ networkState, reloadUserAddress }) => (
@@ -236,7 +235,8 @@ export class ChainMutationButton extends Component {
                     this._onClick({
                       networkState,
                       reloadUserAddress,
-                      postMutation: onClick
+                      postMutation: onClick,
+                      action: props.analyticsId
                     })
                   }
                   disabled={!!(loading || progress)}
@@ -253,10 +253,13 @@ export class ChainMutationButton extends Component {
     )
   }
 
-  _onClick = ({ networkState, reloadUserAddress, postMutation }) => {
+  _onClick = ({ networkState, reloadUserAddress, postMutation, action }) => {
     this.setState({ notReadyError: null }, async () => {
       const address = await reloadUserAddress()
-      let assist = Assist({ expectedNetworkId: networkState.expectedNetworkId })
+      let assist = Assist({
+        expectedNetworkId: networkState.expectedNetworkId,
+        action
+      })
       if (assist.mobile) {
         if (!address) {
           return this.setState({

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -2,8 +2,11 @@ import getWeb3 from '../../api/web3'
 import assist from 'bnc-assist'
 import { BLOCKNATIVE_DAPPID } from '../../config'
 import CONFIG from '../../config'
+import { track } from '../../api/analytics'
+
 console.log({ CONFIG, BLOCKNATIVE_DAPPID })
 const Assist = async ({ action, expectedNetworkId }) => {
+  let msg
   const web3 = await getWeb3()
   // dappid is mandatory so will have throw away id for local usage.
   let testid = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
@@ -33,17 +36,18 @@ const Assist = async ({ action, expectedNetworkId }) => {
         result.status = 'Wrong Network'
       }
     }
-    console.log(`Connect Web3:mobile:${action}:${result.status}`, result)
-    return result
+    msg = `Connect Web3:mobile:${action}:${result.status}`
   } else {
     try {
       result.status = await assistInstance.onboard()
     } catch (error) {
       result.status = error
     } finally {
-      console.log(`Connect web3:desktop:${action}:${result.status}`, result)
-      return result
+      msg = `Connect web3:desktop:${action}:${result.status}`
     }
   }
+  console.log(msg, result)
+  track(msg, result)
+  return result
 }
 export default Assist

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -42,6 +42,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
     console.log('Blocknative failing to get State', e)
   }
   if (state) {
+    console.log('state', JSON.stringify(state.userAgent))
     console.log('state', state)
     let {
       correctNetwork,
@@ -54,7 +55,8 @@ const Assist = async ({ action, expectedNetworkId }) => {
       supportedNetwork,
       accountAddress,
       web3Version,
-      web3Wallet
+      web3Wallet,
+      userAgent
     } = state
     result = {
       correctNetwork,
@@ -68,6 +70,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
       accountAddress,
       web3Version,
       web3Wallet,
+      userAgent,
       ...result
     }
     // Making sure that current provider is set.

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -3,7 +3,7 @@ import assist from 'bnc-assist'
 import { BLOCKNATIVE_DAPPID } from '../../config'
 import CONFIG from '../../config'
 console.log({ CONFIG, BLOCKNATIVE_DAPPID })
-const Assist = async ({ expectedNetworkId }) => {
+const Assist = async ({ action, expectedNetworkId }) => {
   const web3 = await getWeb3()
   // dappid is mandatory so will have throw away id for local usage.
   let testid = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
@@ -23,18 +23,26 @@ const Assist = async ({ expectedNetworkId }) => {
     }
   })
   let state = await assistInstance.getState()
-  console.log('getState')
-  console.log({ state })
+  let result = { state, status: 'Already on boarded' }
   if (state.mobileDevice) {
-    console.log('this is mobile')
-    return { state, mobile: true }
+    result.mobile = true
+    if (!state.web3Wallet) {
+      result.status = 'Mobile wallet not detected'
+    } else {
+      if (state.userCurrentNetworkId !== expectedNetworkId) {
+        result.status = 'Wrong Network'
+      }
+    }
+    console.log(`Connect Web3:mobile:${action}:${result.status}`, result)
+    return result
   } else {
-    console.log('this is desktop')
     try {
-      let onboardResult = await assistInstance.onboard()
-      return { state, onboardResult }
+      result.status = await assistInstance.onboard()
     } catch (error) {
-      return { state, error }
+      result.status = error
+    } finally {
+      console.log(`Connect web3:desktop:${action}:${result.status}`, result)
+      return result
     }
   }
 }

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -75,6 +75,8 @@ const Assist = async ({ action, expectedNetworkId }) => {
     }
     // Making sure that current provider is set.
     result.currentProvider = state.currentProvider
+    // the parsed user agent by mixpanel and blocknative seems wrong.
+    // Get the agent data directly
     result.navigatorUserAgent = navigator && navigator.userAgent
     // We want to know whether the users have any balances in their walllet
     // but don't want to know how much they do.

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -63,7 +63,12 @@ const Assist = async ({ action, expectedNetworkId }) => {
     }
     // Making sure that current provider is set.
     result.currentProvider = state.currentProvider
+    console.log(
+      'currentProvider',
+      JSON.stringify([state.currentProvider, result])
+    )
   } else {
+    console.log('no state', JSON.stringify([result]))
     result.status = 'Problem getting state'
     result.error = true
     result.fallback = true

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -1,10 +1,14 @@
 import getWeb3 from '../../api/web3'
 import assist from 'bnc-assist'
-
+import { BLOCKNATIVE_DAPPID } from '../../config'
+import CONFIG from '../../config'
+console.log({ CONFIG, BLOCKNATIVE_DAPPID })
 const Assist = async ({ expectedNetworkId }) => {
   const web3 = await getWeb3()
+  // dappid is mandatory so will have throw away id for local usage.
+  let testid = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
   let assistInstance = assist.init({
-    dappId: 'c212885d-e81d-416f-ac37-06d9ad2cf5af',
+    dappId: BLOCKNATIVE_DAPPID || testid,
     web3: web3,
     networkId: expectedNetworkId,
     images: {

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -55,8 +55,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
       supportedNetwork,
       accountAddress,
       web3Version,
-      web3Wallet,
-      userAgent
+      web3Wallet
     } = state
     result = {
       correctNetwork,
@@ -70,14 +69,10 @@ const Assist = async ({ action, expectedNetworkId }) => {
       accountAddress,
       web3Version,
       web3Wallet,
-      userAgent,
       ...result
     }
     // Making sure that current provider is set.
     result.currentProvider = state.currentProvider
-    // the parsed user agent by mixpanel and blocknative seems wrong.
-    // Get the agent data directly
-    result.navigatorUserAgent = navigator && navigator.userAgent
     // We want to know whether the users have any balances in their walllet
     // but don't want to know how much they do.
     result.hasBalance = parseInt(state.accountBalance || 0) > 0

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -18,22 +18,20 @@ const Assist = async ({ expectedNetworkId }) => {
       }
     }
   })
-  assistInstance.getState().then(function(state) {
-    console.log('getState')
-    console.log({ state })
-    if (state.mobileDevice) {
-      console.log('this is mobile')
-    } else {
-      console.log('this is desktop')
-      assistInstance
-        .onboard()
-        .then(function(success) {
-          console.log({ success })
-        })
-        .catch(function(error) {
-          console.log({ error })
-        })
+  let state = await assistInstance.getState()
+  console.log('getState')
+  console.log({ state })
+  if (state.mobileDevice) {
+    console.log('this is mobile')
+    return { state, mobile: true }
+  } else {
+    console.log('this is desktop')
+    try {
+      let onboardResult = await assistInstance.onboard()
+      return { state, onboardResult }
+    } catch (error) {
+      return { state, error }
     }
-  })
+  }
 }
 export default Assist

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -23,7 +23,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
     }
   })
   let state = await assistInstance.getState()
-  let result = { status: 'Already on boarded', action }
+  let result = { status: 'Already on boarded', action, error: false }
   if (state) {
     let {
       correctNetwork,
@@ -54,9 +54,11 @@ const Assist = async ({ action, expectedNetworkId }) => {
   if (state.mobileDevice) {
     if (!state.web3Wallet) {
       result.status = 'Mobile wallet not detected'
+      result.error = true
     } else {
       if (state.userCurrentNetworkId !== expectedNetworkId) {
         result.status = 'Wrong Network'
+        result.error = true
       }
     }
   } else {
@@ -64,6 +66,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
       result.status = await assistInstance.onboard()
     } catch (error) {
       result.status = error
+      result.error = true
     }
   }
   track('Connect to web3', result)

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -4,7 +4,15 @@ import { BLOCKNATIVE_DAPPID } from '../../config'
 import { track } from '../../api/analytics'
 
 const Assist = async ({ action, expectedNetworkId }) => {
-  const web3 = await getWeb3()
+  console.log('Assist1')
+  let web3
+  console.log('Assist2')
+  try {
+    web3 = await getWeb3()
+  } catch (e) {
+    console.log('failed to get web3')
+  }
+  console.log('Assist3')
   // dappid is mandatory so will have throw away id for local usage.
   let testid = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
   let assistInstance = assist.init({
@@ -22,6 +30,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
       }
     }
   })
+  console.log('Assist4')
   let state
   let result = {
     status: 'Already on boarded',
@@ -31,11 +40,14 @@ const Assist = async ({ action, expectedNetworkId }) => {
   }
 
   try {
+    console.log('Assist5')
     state = await assistInstance.getState()
   } catch (e) {
     console.log('Blocknative failing to get State', e)
   }
+  console.log('Assist6')
   if (state) {
+    console.log('state', state)
     let {
       correctNetwork,
       currentProvider,

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -4,18 +4,15 @@ import { BLOCKNATIVE_DAPPID } from '../../config'
 import { track } from '../../api/analytics'
 
 const Assist = async ({ action, expectedNetworkId }) => {
-  console.log('Assist1')
   let web3
-  console.log('Assist2')
   try {
     web3 = await getWeb3()
   } catch (e) {
     console.log('failed to get web3')
   }
-  console.log('Assist3')
   // dappid is mandatory so will have throw away id for local usage.
   let testid = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'
-  let assistInstance = assist.init({
+  let assistInstance = await assist.init({
     dappId: BLOCKNATIVE_DAPPID || testid,
     web3: web3,
     networkId: expectedNetworkId,
@@ -30,22 +27,20 @@ const Assist = async ({ action, expectedNetworkId }) => {
       }
     }
   })
-  console.log('Assist4')
   let state
   let result = {
     status: 'Already on boarded',
     action,
     error: false,
-    fallback: false
+    fallback: false,
+    hasBalance: false
   }
 
   try {
-    console.log('Assist5')
     state = await assistInstance.getState()
   } catch (e) {
     console.log('Blocknative failing to get State', e)
   }
-  console.log('Assist6')
   if (state) {
     console.log('state', state)
     let {
@@ -57,6 +52,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
       modernWallet,
       modernWeb3,
       supportedNetwork,
+      accountAddress,
       web3Version,
       web3Wallet
     } = state
@@ -69,18 +65,17 @@ const Assist = async ({ action, expectedNetworkId }) => {
       modernWallet,
       modernWeb3,
       supportedNetwork,
+      accountAddress,
       web3Version,
       web3Wallet,
       ...result
     }
     // Making sure that current provider is set.
     result.currentProvider = state.currentProvider
-    console.log(
-      'currentProvider',
-      JSON.stringify([state.currentProvider, result])
-    )
+    // We want to know whether the users have any balances in their walllet
+    // but don't want to know how much they do.
+    result.hasBalance = parseInt(state.accountBalance || 0) > 0
   } else {
-    console.log('no state', JSON.stringify([result]))
     result.status = 'Problem getting state'
     result.error = true
     result.fallback = true

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -7,23 +7,30 @@ const Assist = ({ expectedNetworkId }) => {
     dappId: 'c212885d-e81d-416f-ac37-06d9ad2cf5af',
     networkId: expectedNetworkId
   })
-  assistInstance
-    .onboard()
-    .then(function(success) {
-      console.log({ success })
-      // User has been successfully onboarded and is ready to transact
-      // This means we can be sure of the follwing user properties:
-      //  - They are using a compatible browser
-      //  - They have a web3-enabled wallet installed
-      //  - The wallet is connected to the config-specified networkId
-      //  - The wallet is unlocked and contains at least `minimumBalance` in wei
-      //  - They have connected their wallet to the dapp, congruent with EIP1102
-    })
-    .catch(function(error) {
-      // The user exited onboarding before completion
-      // Will let you know which stage of onboarding the user reached when they exited
-      console.log('catch***')
-      console.log(error.msg)
-    })
+  assistInstance.getState().then(function(state) {
+    if (state.mobileDevice) {
+      console.log('this is mobile')
+    } else {
+      console.log('this is desktop')
+      assistInstance
+        .onboard()
+        .then(function(success) {
+          console.log({ success })
+          // User has been successfully onboarded and is ready to transact
+          // This means we can be sure of the follwing user properties:
+          //  - They are using a compatible browser
+          //  - They have a web3-enabled wallet installed
+          //  - The wallet is connected to the config-specified networkId
+          //  - The wallet is unlocked and contains at least `minimumBalance` in wei
+          //  - They have connected their wallet to the dapp, congruent with EIP1102
+        })
+        .catch(function(error) {
+          // The user exited onboarding before completion
+          // Will let you know which stage of onboarding the user reached when they exited
+          console.log('catch***')
+          console.log(error.msg)
+        })
+    }
+  })
 }
 export default Assist

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -4,7 +4,6 @@ import { BLOCKNATIVE_DAPPID } from '../../config'
 import CONFIG from '../../config'
 import { track } from '../../api/analytics'
 
-console.log({ CONFIG, BLOCKNATIVE_DAPPID })
 const Assist = async ({ action, expectedNetworkId }) => {
   let msg
   const web3 = await getWeb3()

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -1,5 +1,3 @@
-import React from 'react'
-// import { GlobalConsumer } from '../GlobalState'
 import assist from 'bnc-assist'
 
 const Assist = ({ expectedNetworkId }) => {

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -61,21 +61,13 @@ const Assist = async ({ action, expectedNetworkId }) => {
         result.status = 'Wrong Network'
       }
     }
-    msg = `Connect Web3:mobile:${action}:${state.currentProvider}:${
-      result.status
-    }`
   } else {
     try {
       result.status = await assistInstance.onboard()
     } catch (error) {
       result.status = error
-    } finally {
-      msg = `Connect web3:desktop:${action}:${state && state.currentProvider}:${
-        result.status
-      }`
     }
   }
-  console.log(msg, result)
   track('Connect to web3', result)
   return result
 }

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -1,11 +1,9 @@
 import getWeb3 from '../../api/web3'
 import assist from 'bnc-assist'
 import { BLOCKNATIVE_DAPPID } from '../../config'
-import CONFIG from '../../config'
 import { track } from '../../api/analytics'
 
 const Assist = async ({ action, expectedNetworkId }) => {
-  let msg
   const web3 = await getWeb3()
   // dappid is mandatory so will have throw away id for local usage.
   let testid = 'c212885d-e81d-416f-ac37-06d9ad2cf5af'

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -50,6 +50,8 @@ const Assist = async ({ action, expectedNetworkId }) => {
       web3Wallet,
       ...result
     }
+    // Making sure that current provider is set.
+    result.currentProvider = state.currentProvider
   }
   if (state.mobileDevice) {
     if (!state.web3Wallet) {

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -26,9 +26,35 @@ const Assist = async ({ action, expectedNetworkId }) => {
     }
   })
   let state = await assistInstance.getState()
-  let result = { state, status: 'Already on boarded' }
+  let result = { status: 'Already on boarded', action }
+  if (state) {
+    let {
+      correctNetwork,
+      currentProvider,
+      legacyWallet,
+      legacyWeb3,
+      mobileDevice,
+      modernWallet,
+      modernWeb3,
+      supportedNetwork,
+      web3Version,
+      web3Wallet
+    } = state
+    result = {
+      correctNetwork,
+      currentProvider,
+      legacyWallet,
+      legacyWeb3,
+      mobileDevice,
+      modernWallet,
+      modernWeb3,
+      supportedNetwork,
+      web3Version,
+      web3Wallet,
+      ...result
+    }
+  }
   if (state.mobileDevice) {
-    result.mobile = true
     if (!state.web3Wallet) {
       result.status = 'Mobile wallet not detected'
     } else {
@@ -51,7 +77,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
     }
   }
   console.log(msg, result)
-  track(msg, result)
+  track('Connect to web3', result)
   return result
 }
 export default Assist

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -85,7 +85,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
       result.status = 'Mobile wallet not detected'
       result.error = true
     } else {
-      if (state.userCurrentNetworkId !== expectedNetworkId) {
+      if (state.userCurrentNetworkId !== parseInt(expectedNetworkId)) {
         result.status = 'Wrong Network'
         result.error = true
       }

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -5,7 +5,6 @@ const Assist = async ({ expectedNetworkId }) => {
   const web3 = await getWeb3()
   let assistInstance = assist.init({
     dappId: 'c212885d-e81d-416f-ac37-06d9ad2cf5af',
-    minimumBalance: '10000',
     web3: web3,
     networkId: expectedNetworkId,
     images: {

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -1,0 +1,31 @@
+import React from 'react'
+// import { GlobalConsumer } from '../GlobalState'
+import assist from 'bnc-assist'
+
+const Assist = ({ expectedNetworkId }) => {
+  console.log('ASSIST')
+  console.log({ expectedNetworkId })
+  let assistInstance = assist.init({
+    dappId: 'c212885d-e81d-416f-ac37-06d9ad2cf5af',
+    networkId: expectedNetworkId
+  })
+  assistInstance
+    .onboard()
+    .then(function(success) {
+      console.log({ success })
+      // User has been successfully onboarded and is ready to transact
+      // This means we can be sure of the follwing user properties:
+      //  - They are using a compatible browser
+      //  - They have a web3-enabled wallet installed
+      //  - The wallet is connected to the config-specified networkId
+      //  - The wallet is unlocked and contains at least `minimumBalance` in wei
+      //  - They have connected their wallet to the dapp, congruent with EIP1102
+    })
+    .catch(function(error) {
+      // The user exited onboarding before completion
+      // Will let you know which stage of onboarding the user reached when they exited
+      console.log('catch***')
+      console.log(error.msg)
+    })
+}
+export default Assist

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -20,6 +20,7 @@ const Assist = async ({ expectedNetworkId }) => {
     }
   })
   assistInstance.getState().then(function(state) {
+    console.log('getState')
     console.log({ state })
     if (state.mobileDevice) {
       console.log('this is mobile')

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -1,13 +1,26 @@
+import getWeb3 from '../../api/web3'
 import assist from 'bnc-assist'
 
-const Assist = ({ expectedNetworkId }) => {
-  console.log('ASSIST')
-  console.log({ expectedNetworkId })
+const Assist = async ({ expectedNetworkId }) => {
+  const web3 = await getWeb3()
   let assistInstance = assist.init({
     dappId: 'c212885d-e81d-416f-ac37-06d9ad2cf5af',
-    networkId: expectedNetworkId
+    minimumBalance: '10000',
+    web3: web3,
+    networkId: expectedNetworkId,
+    images: {
+      welcome: {
+        src: 'https://kickback.events/card.png',
+        srcset: 'Welcome to Kickback'
+      },
+      complete: {
+        src: 'https://kickback.events/card.png',
+        srcset: 'Now you are ready to use Kickback'
+      }
+    }
   })
   assistInstance.getState().then(function(state) {
+    console.log({ state })
     if (state.mobileDevice) {
       console.log('this is mobile')
     } else {
@@ -16,19 +29,9 @@ const Assist = ({ expectedNetworkId }) => {
         .onboard()
         .then(function(success) {
           console.log({ success })
-          // User has been successfully onboarded and is ready to transact
-          // This means we can be sure of the follwing user properties:
-          //  - They are using a compatible browser
-          //  - They have a web3-enabled wallet installed
-          //  - The wallet is connected to the config-specified networkId
-          //  - The wallet is unlocked and contains at least `minimumBalance` in wei
-          //  - They have connected their wallet to the dapp, congruent with EIP1102
         })
         .catch(function(error) {
-          // The user exited onboarding before completion
-          // Will let you know which stage of onboarding the user reached when they exited
-          console.log('catch***')
-          console.log(error.msg)
+          console.log({ error })
         })
     }
   })

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -75,6 +75,7 @@ const Assist = async ({ action, expectedNetworkId }) => {
     }
     // Making sure that current provider is set.
     result.currentProvider = state.currentProvider
+    result.navigatorUserAgent = navigator && navigator.userAgent
     // We want to know whether the users have any balances in their walllet
     // but don't want to know how much they do.
     result.hasBalance = parseInt(state.accountBalance || 0) > 0

--- a/src/components/Header/Assist.js
+++ b/src/components/Header/Assist.js
@@ -36,14 +36,18 @@ const Assist = async ({ action, expectedNetworkId }) => {
         result.status = 'Wrong Network'
       }
     }
-    msg = `Connect Web3:mobile:${action}:${result.status}`
+    msg = `Connect Web3:mobile:${action}:${state.currentProvider}:${
+      result.status
+    }`
   } else {
     try {
       result.status = await assistInstance.onboard()
     } catch (error) {
       result.status = error
     } finally {
-      msg = `Connect web3:desktop:${action}:${result.status}`
+      msg = `Connect web3:desktop:${action}:${state && state.currentProvider}:${
+        result.status
+      }`
     }
   }
   console.log(msg, result)

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -39,7 +39,6 @@ function SignInButton() {
       expectedNetworkId: networkState.expectedNetworkId
     })
     const address = await reloadUserAddress()
-    console.log({ networkState })
     if (!networkState.allGood || !address) {
       if (assist.fallback) {
         return showTooltip()

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -2,11 +2,9 @@ import React from 'react'
 import styled from 'react-emotion'
 
 import { GlobalConsumer } from '../../GlobalState'
-import Tooltip from '../Tooltip'
 import Button from '../Forms/Button'
 import Avatar from '../User/Avatar'
 import { EDIT_PROFILE } from '../../modals'
-import { CANNOT_RESOLVE_ACCOUNT_ADDRESS } from '../../utils/errors'
 import Assist from './Assist'
 
 const Account = styled('div')`

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -26,20 +26,12 @@ const Username = styled('div')`
 `
 
 function SignInButton() {
-  const _signIn = ({
-    showTooltip,
-    hideTooltip,
-    signIn,
-    networkState,
-    reloadUserAddress
-  }) => async () => {
-    hideTooltip()
-    Assist({ expectedNetworkId: networkState.expectedNetworkId })
+  const _signIn = ({ signIn, networkState, reloadUserAddress }) => async () => {
+    await Assist({ expectedNetworkId: networkState.expectedNetworkId })
     const address = await reloadUserAddress()
 
     if (!networkState.allGood || !address) {
       console.log('not good')
-      return showTooltip()
     } else {
       console.log('good')
     }
@@ -76,24 +68,17 @@ function SignInButton() {
             </Account>
           </>
         ) : (
-          <Tooltip text={CANNOT_RESOLVE_ACCOUNT_ADDRESS} position="left">
-            {({ tooltipElement, showTooltip, hideTooltip }) => (
-              <Button
-                type="light"
-                onClick={_signIn({
-                  showTooltip,
-                  hideTooltip,
-                  signIn,
-                  reloadUserAddress,
-                  networkState
-                })}
-                analyticsId="Sign In"
-              >
-                {tooltipElement}
-                Sign in
-              </Button>
-            )}
-          </Tooltip>
+          <Button
+            type="light"
+            onClick={_signIn({
+              signIn,
+              reloadUserAddress,
+              networkState
+            })}
+            analyticsId="Sign In"
+          >
+            Sign in
+          </Button>
         )
       }}
     </GlobalConsumer>

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -7,6 +7,7 @@ import Button from '../Forms/Button'
 import Avatar from '../User/Avatar'
 import { EDIT_PROFILE } from '../../modals'
 import { CANNOT_RESOLVE_ACCOUNT_ADDRESS } from '../../utils/errors'
+import Assist from './Assist'
 
 const Account = styled('div')`
   display: flex;
@@ -33,11 +34,14 @@ function SignInButton() {
     reloadUserAddress
   }) => async () => {
     hideTooltip()
-
+    Assist({ expectedNetworkId: networkState.expectedNetworkId })
     const address = await reloadUserAddress()
 
     if (!networkState.allGood || !address) {
+      console.log('not good')
       return showTooltip()
+    } else {
+      console.log('good')
     }
 
     signIn()

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -39,13 +39,14 @@ function SignInButton() {
       expectedNetworkId: networkState.expectedNetworkId
     })
     const address = await reloadUserAddress()
-    if (assist.fallback) {
-      if (!networkState.allGood || !address) {
+    console.log({ networkState })
+    if (!networkState.allGood || !address) {
+      if (assist.fallback) {
         return showTooltip()
       }
+    } else {
+      signIn()
     }
-
-    signIn()
   }
 
   return (

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -41,7 +41,7 @@ function SignInButton() {
     const address = await reloadUserAddress()
 
     if (assist.mobileDevice) {
-      if (assist.error || !networkState.allGood || !address) {
+      if (!networkState.allGood || !address) {
         return showTooltip()
       }
     }

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -33,7 +33,6 @@ function SignInButton() {
     networkState,
     reloadUserAddress
   }) => async () => {
-    console.log('signIn')
     hideTooltip()
     let assist = await Assist({
       expectedNetworkId: networkState.expectedNetworkId
@@ -46,6 +45,7 @@ function SignInButton() {
         return showTooltip()
       }
     }
+
     signIn()
   }
 

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -41,7 +41,7 @@ function SignInButton() {
     const address = await reloadUserAddress()
 
     if (assist.mobileDevice) {
-      if (!networkState.allGood || !address) {
+      if (assist.error || !networkState.allGood || !address) {
         return showTooltip()
       }
     }

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -39,8 +39,7 @@ function SignInButton() {
       expectedNetworkId: networkState.expectedNetworkId
     })
     const address = await reloadUserAddress()
-
-    if (assist.mobileDevice) {
+    if (assist.fallback) {
       if (!networkState.allGood || !address) {
         return showTooltip()
       }

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -38,7 +38,6 @@ function SignInButton() {
       action: 'Sign in',
       expectedNetworkId: networkState.expectedNetworkId
     })
-    console.log({ assist })
     const address = await reloadUserAddress()
 
     if (assist.mobileDevice) {

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -2,9 +2,11 @@ import React from 'react'
 import styled from 'react-emotion'
 
 import { GlobalConsumer } from '../../GlobalState'
+import Tooltip from '../Tooltip'
 import Button from '../Forms/Button'
 import Avatar from '../User/Avatar'
 import { EDIT_PROFILE } from '../../modals'
+import { CANNOT_RESOLVE_ACCOUNT_ADDRESS } from '../../utils/errors'
 import Assist from './Assist'
 
 const Account = styled('div')`
@@ -24,16 +26,26 @@ const Username = styled('div')`
 `
 
 function SignInButton() {
-  const _signIn = ({ signIn, networkState, reloadUserAddress }) => async () => {
-    await Assist({ expectedNetworkId: networkState.expectedNetworkId })
+  const _signIn = ({
+    showTooltip,
+    hideTooltip,
+    signIn,
+    networkState,
+    reloadUserAddress
+  }) => async () => {
+    console.log('signIn')
+    hideTooltip()
+    let assist = await Assist({
+      expectedNetworkId: networkState.expectedNetworkId
+    })
+    console.log({ assist })
     const address = await reloadUserAddress()
 
-    if (!networkState.allGood || !address) {
-      console.log('not good')
-    } else {
-      console.log('good')
+    if (assist.mobile) {
+      if (!networkState.allGood || !address) {
+        return showTooltip()
+      }
     }
-
     signIn()
   }
 
@@ -66,17 +78,24 @@ function SignInButton() {
             </Account>
           </>
         ) : (
-          <Button
-            type="light"
-            onClick={_signIn({
-              signIn,
-              reloadUserAddress,
-              networkState
-            })}
-            analyticsId="Sign In"
-          >
-            Sign in
-          </Button>
+          <Tooltip text={CANNOT_RESOLVE_ACCOUNT_ADDRESS} position="left">
+            {({ tooltipElement, showTooltip, hideTooltip }) => (
+              <Button
+                type="light"
+                onClick={_signIn({
+                  showTooltip,
+                  hideTooltip,
+                  signIn,
+                  reloadUserAddress,
+                  networkState
+                })}
+                analyticsId="Sign In"
+              >
+                {tooltipElement}
+                Sign in
+              </Button>
+            )}
+          </Tooltip>
         )
       }}
     </GlobalConsumer>

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -35,6 +35,7 @@ function SignInButton() {
   }) => async () => {
     hideTooltip()
     let assist = await Assist({
+      action: 'Sign in',
       expectedNetworkId: networkState.expectedNetworkId
     })
     console.log({ assist })
@@ -60,7 +61,9 @@ function SignInButton() {
         showModal
       }) => {
         const twitterProfile =
-          userProfile && userProfile.social.find(s => s.type === 'twitter')
+          userProfile &&
+          userProfile.social &&
+          userProfile.social.find(s => s.type === 'twitter')
         return loggedIn ? (
           <>
             {/* <Notifications>Notification</Notifications> */}

--- a/src/components/Header/SignInButton.js
+++ b/src/components/Header/SignInButton.js
@@ -41,7 +41,7 @@ function SignInButton() {
     console.log({ assist })
     const address = await reloadUserAddress()
 
-    if (assist.mobile) {
+    if (assist.mobileDevice) {
       if (!networkState.allGood || !address) {
         return showTooltip()
       }

--- a/src/components/SingleEvent/EventInfo.js
+++ b/src/components/SingleEvent/EventInfo.js
@@ -13,7 +13,6 @@ import { ReactComponent as DefaultEthIcon } from '../svg/Ethereum.svg'
 import DefaultEventDate from '../Utils/EventDate'
 import { ReactComponent as DefaultPinIcon } from '../svg/Pin.svg'
 import { ReactComponent as DefaultInfoIcon } from '../svg/info.svg'
-// import Tooltip from '../Tooltip/Tooltip'
 
 import moment from 'moment'
 import { toEthVal } from '../../utils/units'

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -7,6 +7,7 @@ import styled from 'react-emotion'
 
 const DefaultTooltip = styled(ReactTooltip)`
   z-index: 1;
+  max-width: 80%;
 `
 
 export default class Tooltip extends Component {

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,5 +1,5 @@
 export const CANNOT_RESOLVE_ACCOUNT_ADDRESS =
-  'Please ensure your browser is connected to the Ethereum network and that we can access your account address.'
+  'Please ensure your browser is connected to the Ethereum network and that we can access your account address. Make sure that privacy mode is off, too'
 
 export const CANNOT_RESOLVE_CORRECT_NETWORK =
   'Please ensure your browser is connected to the correct Ethereum network'

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,13 +64,14 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/generator@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.3.tgz#2103ec9c42d9bdad9190a6ad5ff2d456fd7b8673"
+"@babel/generator@^7.1.3", "@babel/generator@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.0.tgz#c230e79589ae7a729fd4631b9ded4dc220418196"
+  integrity sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==
   dependencies:
-    "@babel/types" "^7.1.3"
+    "@babel/types" "^7.4.0"
     jsesc "^2.5.1"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
@@ -151,6 +152,7 @@
 "@babel/helper-function-name@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
   dependencies:
     "@babel/helper-get-function-arity" "^7.0.0"
     "@babel/template" "^7.1.0"
@@ -165,6 +167,7 @@
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
   dependencies:
     "@babel/types" "^7.0.0"
 
@@ -255,11 +258,12 @@
   dependencies:
     "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-split-export-declaration@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
+"@babel/helper-split-export-declaration@^7.0.0", "@babel/helper-split-export-declaration@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz#571bfd52701f492920d63b7f735030e9a3e10b55"
+  integrity sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/types" "^7.4.0"
 
 "@babel/helper-wrap-function@^7.1.0":
   version "7.1.0"
@@ -290,6 +294,7 @@
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -299,9 +304,10 @@
   version "7.0.0-beta.53"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.53.tgz#1f45eb617bf9463d482b2c04d349d9e4edbf4892"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.3.tgz#2c92469bac2b7fbff810b67fca07bd138b48af77"
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.3", "@babel/parser@^7.4.0":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.2.tgz#b4521a400cb5a871eab3890787b4bc1326d38d91"
+  integrity sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==
 
 "@babel/parser@^7.2.2", "@babel/parser@^7.3.4":
   version "7.3.4"
@@ -894,7 +900,16 @@
     babylon "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/template@^7.1.0", "@babel/template@^7.1.2":
+"@babel/template@^7.1.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
+  integrity sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.4.0"
+    "@babel/types" "^7.4.0"
+
+"@babel/template@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
   dependencies:
@@ -926,7 +941,22 @@
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0":
+"@babel/traverse@^7.0.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.0.tgz#14006967dd1d2b3494cdd650c686db9daf0ddada"
+  integrity sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.0"
+    "@babel/parser" "^7.4.0"
+    "@babel/types" "^7.4.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
+"@babel/traverse@^7.1.0":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.4.tgz#f4f83b93d649b4b2c91121a9087fa2fa949ec2b4"
   dependencies:
@@ -963,12 +993,13 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.3.tgz#3a767004567060c2f40fca49a304712c525ee37d"
+"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.3", "@babel/types@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.0.tgz#670724f77d24cce6cc7d8cf64599d511d164894c"
+  integrity sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==
   dependencies:
     esutils "^2.0.2"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.1.6", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.4":
@@ -3841,7 +3872,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1:
+chalk@2.4.1, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -3849,7 +3880,7 @@ chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.3.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@2.4.2, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4091,6 +4122,7 @@ color-convert@^1.3.0, color-convert@^1.9.0, color-convert@^1.9.1:
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@^1.0.0:
   version "1.1.4"
@@ -5610,6 +5642,7 @@ eslint-plugin-react@7.12.4:
 eslint-scope@3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -5628,6 +5661,7 @@ eslint-utils@^1.3.1:
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
 eslint@5.12.0:
   version "5.12.0"
@@ -5702,6 +5736,7 @@ esquery@^1.0.1:
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
   dependencies:
     estraverse "^4.1.0"
 
@@ -5712,6 +5747,7 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
 etag@~1.8.1:
   version "1.8.1"
@@ -6747,7 +6783,12 @@ global@^4.3.2, global@~4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.1.0:
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
+  integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
+
+globals@^11.7.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
 
@@ -6920,6 +6961,7 @@ has-flag@^2.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
@@ -8395,8 +8437,9 @@ jsesc@^1.3.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
 jsesc@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -9404,6 +9447,7 @@ ms@2.0.0:
 ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -13594,6 +13638,7 @@ to-fast-properties@^1.0.3:
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -13656,6 +13701,7 @@ tr46@^1.0.1:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 trim@0.0.1:
   version "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3391,10 +3391,10 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.10.0, bn.js@^4.11.3, bn.js@^4
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
-bnc-assist@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/bnc-assist/-/bnc-assist-0.4.0.tgz#d5df5ba34162998004e49580299cd61ba13a9660"
-  integrity sha512-T+M8aIHV48IHCrgopwc6n6PONVyje6EE7kd1/xuF6tlY6q51pTWTUfHduXdUANsOVfUh8YH7s3DMhtfjUIWPKQ==
+bnc-assist@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/bnc-assist/-/bnc-assist-0.5.0.tgz#651c85926af550d5f7cd94d9f50df057115695b7"
+  integrity sha512-aHAQhztFLQeqVXtl5BCP4I7DKCtQe+v+Qcs+bZSYH8/2xbympW0Yj9BuYukioWY3CfxUbiJu+EKXjvt2uUhmcQ==
   dependencies:
     "@babel/polyfill" "^7.0.0"
     babel-eslint "^10.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,6 +754,14 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
 
+"@babel/polyfill@^7.0.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.0.tgz#90f9d68ae34ac42ab4b4aa03151848f536960218"
+  integrity sha512-bVsjsrtsDflIHp5I6caaAa2V25Kzn50HKPL6g3X0P0ni1ks+58cPB8Mz6AOKVuRPgaVdq/OwEUc/1vKqX+Mo4A==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/preset-env@7.3.1":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.3.1.tgz#389e8ca6b17ae67aaf9a2111665030be923515db"
@@ -2260,6 +2268,18 @@ babel-eslint@9.0.0:
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
+
 babel-eslint@^8.2.3:
   version "8.2.6"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.6.tgz#6270d0c73205628067c0f7ae1693a9e797acefd9"
@@ -3327,6 +3347,11 @@ bluebird@^3.4.7, bluebird@^3.5.0, bluebird@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
 
+bluebird@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
+  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
+
 bn.js@4.11.6:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
@@ -3334,6 +3359,16 @@ bn.js@4.11.6:
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.10.0, bn.js@^4.11.3, bn.js@^4.11.6, bn.js@^4.4.0, bn.js@^4.8.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+
+bnc-assist@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/bnc-assist/-/bnc-assist-0.4.0.tgz#d5df5ba34162998004e49580299cd61ba13a9660"
+  integrity sha512-T+M8aIHV48IHCrgopwc6n6PONVyje6EE7kd1/xuF6tlY6q51pTWTUfHduXdUANsOVfUh8YH7s3DMhtfjUIWPKQ==
+  dependencies:
+    "@babel/polyfill" "^7.0.0"
+    babel-eslint "^10.0.1"
+    bluebird "^3.5.3"
+    bowser "^2.0.0-beta.3"
 
 body-parser@1.18.3, body-parser@^1.16.0:
   version "1.18.3"
@@ -3382,6 +3417,11 @@ boom@5.x.x:
 bowser@^1.0.0, bowser@^1.7.3:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
+
+bowser@^2.0.0-beta.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.1.2.tgz#35cba0487362ab6a8cea8fd094bf5670b408c8d3"
+  integrity sha512-K64ZigDayqlptyKVEiCDPPKQ2/SyPT/jsgJPwZOcpR3WA2bYojlHLeTHN+IRc/vbMz3F6CV62nnAo01+0zYrsQ==
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"
@@ -4295,6 +4335,11 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
+core-js@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -11914,6 +11959,11 @@ regenerator-runtime@^0.11.0:
 regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
## Changes

- Allow mixpanel to pass custom properties (and send wallet provider info,etc)
- Track "Connect to Web3" event to mixpanel
- Integrate with blocknative sdk for desktop
- Falls back to the prvious behavior if mobile (as Blocknative doesn't support mobile fully)

## Out of scope (For this PR)

- https://www.blocknative.com/transaction-awareness

## Acceptance criteria

### Desktop

- Safari => Show "This browser is not supported" modal

<img width="713" alt="Screenshot 2019-03-30 at 20 27 00" src="https://user-images.githubusercontent.com/2630/55282029-f88df080-5333-11e9-87e7-3fbe80c3471d.png">


- Chrome (Incognito) => Show "Let's get you started" modal

<img width="746" alt="Screenshot 2019-03-30 at 21 04 37" src="https://user-images.githubusercontent.com/2630/55282045-54f11000-5334-11e9-96f6-5f17944f952d.png">

- Chrome (Logged out) => Show "Login to Metamask" modal

<img width="819" alt="Screenshot 2019-03-30 at 21 50 55" src="https://user-images.githubusercontent.com/2630/55282130-08a6cf80-5336-11e9-8284-c87b1d4027f7.png">

- Chrome (Wrong network) => Show "Wrong Network" modal

<img width="724" alt="Screenshot 2019-03-30 at 21 53 47" src="https://user-images.githubusercontent.com/2630/55282149-58859680-5336-11e9-913a-2c4a1b4cda41.png">

- Chrome (Connected) => Show nothing


### Mobile

NOTE: Block native assist does not support Mobile yet, so make sure to disable the feature.

- Make sure it shows tooltip warning for normal browsers
- Make sure it works for Status and Opera

### Mixpanel

- Make sure that it passes `currentProvider` field