### PR TITLE
Fix wrong etherscan link

### DIFF
--- a/src/components/ExternalLinks/EtherScanLink.js
+++ b/src/components/ExternalLinks/EtherScanLink.js
@@ -14,13 +14,13 @@ const EtherScanLink = ({ address, tx, children }) => (
   <GlobalConsumer>
     {({ networkState: { expectedNetworkName, expectedNetworkId } }) => {
       const prefix =
-        '1' === expectedNetworkId ? '' : `${expectedNetworkName.toLowerCase()}`
+        '1' === expectedNetworkId ? '' : `${expectedNetworkName.toLowerCase()}.`
 
       let link
       if (address) {
-        link = `https://${prefix}.etherscan.io/address/${address}`
+        link = `https://${prefix}etherscan.io/address/${address}`
       } else if (tx) {
-        link = `https://${prefix}.etherscan.io/tx/${tx}`
+        link = `https://${prefix}etherscan.io/tx/${tx}`
       }
       return link ? (
         <Link target="_blank" href={link}>


### PR DESCRIPTION
Previously there was a bug displaying rinkeby like `https://rinkeby..etherscan.io` the previous fix fixed that but on live page it was now linking to `https://.etherscan.io`