### PR TITLE
Revert from send('eth_requestAccounts') to window.ethereum.enable()

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "apollo-link-state": "^0.4.1",
     "apollo-upload-client": "^10.0.0",
     "apollo-utilities": "^1.0.21",
-    "bnc-assist": "^0.5.2",
+    "bnc-assist": "^0.6.1",
     "decimal.js": "^10.0.1",
     "emotion": "^9.2.6",
     "es6-promisify": "^6.0.0",

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -176,6 +176,7 @@ export async function getEvents(address, abi) {
 
 export async function getAccount() {
   let accountIndex = 0
+  let accounts
   /* Query params account switch for testing */
   if (localEndpoint === true) {
     const query = window.location.search
@@ -187,21 +188,21 @@ export async function getAccount() {
   }
   try {
     const web3 = await getWeb3()
-    const accounts = await web3.eth.getAccounts()
-
-    if (accounts.length > 0) {
-      return accounts[accountIndex]
-    } else {
-      try {
-        const accounts = await window.ethereum.send('eth_requestAccounts')
-        return accounts[accountIndex]
-      } catch (error) {
-        console.warn('Did not allow app to access dapp browser')
-        throw error
-      }
+    accounts = await web3.eth.getAccounts()
+  } catch (error) {
+    console.warn('Cannot get accounts', error)
+  }
+  if (accounts && accounts.length > 0) {
+    return accounts[accountIndex]
+  } else {
+    try {
+      const accounts = await window.ethereum.enable()
+      console.log({ accounts })
+      // When user denies
+      return accounts && accounts[accountIndex]
+    } catch (error) {
+      console.warn('Did not allow app to access dapp browser', error)
     }
-  } catch (_) {
-    return null
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,18 +2300,6 @@ babel-eslint@9.0.0:
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
-babel-eslint@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
-  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@babel/types" "^7.0.0"
-    eslint-scope "3.7.1"
-    eslint-visitor-keys "^1.0.0"
-
 babel-eslint@^8.2.3:
   version "8.2.6"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.6.tgz#6270d0c73205628067c0f7ae1693a9e797acefd9"
@@ -3393,15 +3381,15 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.10.0, bn.js@^4.11.3, bn.js@^4
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
-bnc-assist@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/bnc-assist/-/bnc-assist-0.5.2.tgz#41e4f8553f7e758de0eb7f4c6b9959686aec48ed"
-  integrity sha512-hQRYvfdR8EvXKB8jUcSUKJMxT3npO7zSfohzjK3+2MI/qqj+UAvFIerxTO0dDR8SUKnWnDIUrSO8kA7rqgxGiQ==
+bnc-assist@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/bnc-assist/-/bnc-assist-0.6.1.tgz#23cb25d004ef159a90975f865544800372efba29"
+  integrity sha512-GI5SoVUhOulP5siDP7fbmhbAMevfA5a7dXXURgwbT1zhYqkHpi4NlGzpaYJp8kubNpqRMdU6/xdtWlAin/Nnqg==
   dependencies:
     "@babel/polyfill" "^7.0.0"
-    babel-eslint "^10.0.1"
     bluebird "^3.5.3"
     bowser "^2.0.0-beta.3"
+    core-js "2"
     uuid "^3.3.2"
 
 body-parser@1.18.3, body-parser@^1.16.0:
@@ -4363,6 +4351,11 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+core-js@2, core-js@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
+
 core-js@2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
@@ -4375,11 +4368,6 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-
-core-js@^2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
-  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
This is because Metamask blows up with 'TypeErrore is not a function' whenever user denies privacy access to Metamask with the new function so falling back to the deprecated function. I also add error message into console.warn and remove meaningless throw which get caught again in the outer loop.