### PR TITLE
Fix a race condition in web3 provider initialization code

### DIFF
--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -27,3 +27,19 @@ export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 export const isEmptyAddress = address => {
   return !address || address === EMPTY_ADDRESS
 }
+
+export function lazyAsync(getter) {
+  let promise
+  let result
+
+  return async () => {
+    if (result) return result
+    if (!promise) {
+      promise = getter().then(res => {
+        result = res
+        return res
+      })
+    }
+    return promise
+  }
+}

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -7,8 +7,8 @@ import { getProvider } from '../GlobalState'
 import { NEW_BLOCK } from '../utils/events'
 import { clientInstance } from '../graphql'
 import { NETWORK_ID_QUERY } from '../graphql/queries'
+import { lazyAsync } from './utils'
 
-let web3
 let networkState = {}
 let localEndpoint = false
 
@@ -65,88 +65,87 @@ const isLocalNetwork = id => {
   }
 }
 
-async function getWeb3() {
-  if (!web3) {
-    try {
-      networkState = { allGood: true }
-      const result = await clientInstance.query({
-        query: NETWORK_ID_QUERY
-      })
+const getWeb3 = lazyAsync(async () => {
+  let web3
 
-      if (result.error) {
-        throw new Error(result.error)
-      }
-      networkState.expectedNetworkId = result.data.networkId
-      networkState.expectedNetworkName = getNetworkName(
-        networkState.expectedNetworkId
-      )
-      if (window.ethereum) {
-        web3 = new Web3(window.ethereum)
-      } else if (window.web3 && window.web3.currentProvider) {
-        web3 = new Web3(window.web3.currentProvider)
-        networkState.readOnly = false
-      } else {
-        //local node
-        const url = 'http://localhost:8545'
+  try {
+    console.log('Initializing web3')
+    networkState = { allGood: true }
+    const result = await clientInstance.query({
+      query: NETWORK_ID_QUERY
+    })
 
-        try {
-          await fetch(url)
+    if (result.error) {
+      throw new Error(result.error)
+    }
+    networkState.expectedNetworkId = result.data.networkId
+    networkState.expectedNetworkName = getNetworkName(
+      networkState.expectedNetworkId
+    )
+    if (window.ethereum) {
+      web3 = new Web3(window.ethereum)
+    } else if (window.web3 && window.web3.currentProvider) {
+      web3 = new Web3(window.web3.currentProvider)
+      networkState.readOnly = false
+    } else {
+      //local node
+      const url = 'http://localhost:8545'
+
+      try {
+        await fetch(url)
+        localEndpoint = true
+        web3 = new Web3(new Web3.providers.HttpProvider(url))
+      } catch (error) {
+        if (
+          error.readyState === 4 &&
+          (error.status === 400 || error.status === 200)
+        ) {
           localEndpoint = true
           web3 = new Web3(new Web3.providers.HttpProvider(url))
-        } catch (error) {
-          if (
-            error.readyState === 4 &&
-            (error.status === 400 || error.status === 200)
-          ) {
-            localEndpoint = true
-            web3 = new Web3(new Web3.providers.HttpProvider(url))
-          } else {
-            web3 = new Web3(
-              getNetworkProviderUrl(networkState.expectedNetworkId)
-            )
-            networkState.readOnly = true
-          }
-        } finally {
-          if (web3 && localEndpoint) {
-            console.log('Success: Local node active')
-          } else if (web3) {
-            console.log('Success: Cloud node active')
-          }
+        } else {
+          web3 = new Web3(getNetworkProviderUrl(networkState.expectedNetworkId))
+          networkState.readOnly = true
+        }
+      } finally {
+        if (web3 && localEndpoint) {
+          console.log('Success: Local node active')
+        } else if (web3) {
+          console.log('Success: Cloud node active')
         }
       }
-      networkState.networkId = `${await web3.eth.net.getId()}`
-      networkState.networkName = getNetworkName(networkState.networkId)
-      networkState.isLocalNetwork = isLocalNetwork(networkState.networkId)
-      if (networkState.networkId !== networkState.expectedNetworkId) {
-        networkState.wrongNetwork = true
-        networkState.allGood = false
-      }
-      // if web3 not set then something failed
-      if (!web3) {
-        networkState.allGood = false
-        throw new Error('Error setting up web3')
-      }
-
-      // poll for blocks
-      setInterval(async () => {
-        try {
-          const block = await web3.eth.getBlock('latest')
-          events.emit(NEW_BLOCK, block)
-        } catch (__) {
-          /* nothing to do */
-        }
-      }, 10000)
-    } catch (err) {
-      console.warn(err)
-      web3 = null
-    } finally {
-      // update global state with current network state
-      updateGlobalState()
     }
+    networkState.networkId = `${await web3.eth.net.getId()}`
+    networkState.networkName = getNetworkName(networkState.networkId)
+    networkState.isLocalNetwork = isLocalNetwork(networkState.networkId)
+    if (networkState.networkId !== networkState.expectedNetworkId) {
+      networkState.wrongNetwork = true
+      networkState.allGood = false
+    }
+    // if web3 not set then something failed
+    if (!web3) {
+      networkState.allGood = false
+      throw new Error('Error setting up web3')
+    }
+
+    // poll for blocks
+    setInterval(async () => {
+      try {
+        const block = await web3.eth.getBlock('latest')
+        events.emit(NEW_BLOCK, block)
+      } catch (__) {
+        /* nothing to do */
+      }
+    }, 10000)
+  } catch (err) {
+    console.warn(err)
+    web3 = null
+  } finally {
+    // update global state with current network state
+    updateGlobalState()
   }
 
   return web3
-}
+})
 
 export async function getDeployerAddress() {
   // if local env doesn't specify address then assume we're on a public net


### PR DESCRIPTION
# The problem
On startup `getWeb3` function gets called multiple times. Since it's async the module's `web3` variable only get's set at the end of execution, after an API call. This means that the second call to `getWeb3` function also starts initializing the web3 provider. This leads to multiple web3 instances being created.

# The solution
This PR introduces the `lazyAsync` helper function. It ensures that even if it gets called multiple times at once, the code is only ever run once and the subsequent calls all wait for the first promise to resolve.