### PR TITLE
Check if TRAVIS_SECURE_ENV_VARS is available

### DIFF
--- a/scripts/deployTravisBuildToSurge.sh
+++ b/scripts/deployTravisBuildToSurge.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # From https://medium.com/onfido-tech/travis-surge-github-auto-deploy-every-pr-branch-and-tag-a6c8c790831f
+echo "TRAVIS_SECURE_ENV_VARS: $TRAVIS_SECURE_ENV_VARS"
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
   if [ "$TRAVIS_SECURE_ENV_VARS" != "true" ]

--- a/scripts/deployTravisBuildToSurge.sh
+++ b/scripts/deployTravisBuildToSurge.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 # From https://medium.com/onfido-tech/travis-surge-github-auto-deploy-every-pr-branch-and-tag-a6c8c790831f
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]
+if [ "$TRAVIS_PULL_REQUEST" != "false"]
 then
-  echo "Deploying PR branch to surge..."
+  if [ "$TRAVIS_SECURE_ENV_VARS" != "true"]
+  then
+    echo "Deploying PR branch to surge..."
+  else
+    echo "No secure envs (probably PR from forks), skipping."
+    exit -1
+  fi
 else
   echo "Not running on PR, skipping."
   exit -1

--- a/scripts/deployTravisBuildToSurge.sh
+++ b/scripts/deployTravisBuildToSurge.sh
@@ -6,7 +6,7 @@ then
   then
     echo "Deploying PR branch to surge..."
   else
-    echo "No secure envs (probably PR from forks), skipping."
+    echo "No secure envs (probably PR from a fork), skipping."
     exit -1
   fi
 else

--- a/scripts/deployTravisBuildToSurge.sh
+++ b/scripts/deployTravisBuildToSurge.sh
@@ -6,23 +6,21 @@ then
   if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]
   then
     echo "Deploying PR branch to surge..."
+    REPO_SLUG_ARRAY=(${TRAVIS_REPO_SLUG//\// })
+    REPO_OWNER=${REPO_SLUG_ARRAY[0]}
+    REPO_NAME=${REPO_SLUG_ARRAY[1]}
+    DEPLOY_PATH=./build
+    DEPLOY_SUBDOMAIN=pr${TRAVIS_PULL_REQUEST}
+    DEPLOY_DOMAIN=https://${DEPLOY_SUBDOMAIN}-${REPO_NAME}-${REPO_OWNER}.surge.sh
+    echo $DEPLOY_DOMAIN
+    cp ${DEPLOY_PATH}/index.html ${DEPLOY_PATH}/200.html
+    surge -p ${DEPLOY_PATH} -d $DEPLOY_DOMAIN
+    GITHUB_PR_COMMENTS=https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments
+    curl -u "noblocknoparty-devs:${GITHUB_API_TOKEN}" --request POST ${GITHUB_PR_COMMENTS} --data '{"body":"PR deployed at: '${DEPLOY_DOMAIN}'"}'
   else
     echo "No secure envs (probably PR from a fork), skipping."
-    exit -1
   fi
 else
   echo "Not running on PR, skipping."
   exit -1
 fi
-
-REPO_SLUG_ARRAY=(${TRAVIS_REPO_SLUG//\// })
-REPO_OWNER=${REPO_SLUG_ARRAY[0]}
-REPO_NAME=${REPO_SLUG_ARRAY[1]}
-DEPLOY_PATH=./build
-DEPLOY_SUBDOMAIN=pr${TRAVIS_PULL_REQUEST}
-DEPLOY_DOMAIN=https://${DEPLOY_SUBDOMAIN}-${REPO_NAME}-${REPO_OWNER}.surge.sh
-echo $DEPLOY_DOMAIN
-cp ${DEPLOY_PATH}/index.html ${DEPLOY_PATH}/200.html
-surge -p ${DEPLOY_PATH} -d $DEPLOY_DOMAIN
-GITHUB_PR_COMMENTS=https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments
-curl -u "noblocknoparty-devs:${GITHUB_API_TOKEN}" --request POST ${GITHUB_PR_COMMENTS} --data '{"body":"PR deployed at: '${DEPLOY_DOMAIN}'"}'

--- a/scripts/deployTravisBuildToSurge.sh
+++ b/scripts/deployTravisBuildToSurge.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # From https://medium.com/onfido-tech/travis-surge-github-auto-deploy-every-pr-branch-and-tag-a6c8c790831f
-if [ "$TRAVIS_PULL_REQUEST" != "false"]
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
-  if [ "$TRAVIS_SECURE_ENV_VARS" != "true"]
+  if [ "$TRAVIS_SECURE_ENV_VARS" != "true" ]
   then
     echo "Deploying PR branch to surge..."
   else

--- a/scripts/deployTravisBuildToSurge.sh
+++ b/scripts/deployTravisBuildToSurge.sh
@@ -3,7 +3,7 @@
 echo "TRAVIS_SECURE_ENV_VARS: $TRAVIS_SECURE_ENV_VARS"
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
-  if [ "$TRAVIS_SECURE_ENV_VARS" != "true" ]
+  if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]
   then
     echo "Deploying PR branch to surge..."
   else


### PR DESCRIPTION
This is to skip deploying to surge and make comment on PR as travis removes any secure variables (eg: SURGE_TOKEN) if PR is from untrusted party such as from forks.

https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables