### PR TITLE
Disable RSVP button with insufficient ETH

### DIFF
--- a/src/api/resolvers/tokenResolvers.js
+++ b/src/api/resolvers/tokenResolvers.js
@@ -274,9 +274,19 @@ const resolvers = {
     },
     async getTokenAllowance(_, { tokenAddress, partyAddress }) {
       const web3 = await getWeb3Read()
-      const contract = getTokenContract(web3, tokenAddress, detailedERC20ABI)
+      const account = await getAccount()
+
       try {
-        const account = await getAccount()
+        // If token is Ether then give ether balance as allowance
+        if (isEmptyAddress(tokenAddress)) {
+          const balance = await web3.eth.getBalance(account)
+          return {
+            balance,
+            allowance: balance
+          }
+        }
+
+        const contract = getTokenContract(web3, tokenAddress, detailedERC20ABI)
         const allowance = await contract.allowance(account, partyAddress).call()
         const balance = await contract.balanceOf(account).call()
         return { allowance, balance }

--- a/src/components/SingleEvent/Approve.js
+++ b/src/components/SingleEvent/Approve.js
@@ -6,7 +6,6 @@ import { APPROVE_TOKEN } from '../../graphql/mutations'
 import { Going } from './Status'
 import WarningBox from '../WarningBox'
 import Currency from '../SingleEvent/Currency'
-import { EMPTY_ADDRESS } from '../../api/utils'
 
 const Approve = ({
   tokenAddress,
@@ -20,7 +19,8 @@ const Approve = ({
   hasBalance,
   refetch
 }) => {
-  const canRSVP = tokenAddress === EMPTY_ADDRESS || (isAllowed && hasBalance)
+  const canRSVP = isAllowed && hasBalance
+
   if (canRSVP) {
     return <Going>You can now RSVP</Going>
   } else if (!hasBalance) {

--- a/src/components/SingleEvent/EventCTA.js
+++ b/src/components/SingleEvent/EventCTA.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'react-emotion'
 import { PARTICIPANT_STATUS, calculateNumAttended } from '@wearekickback/shared'
-import { isEmptyAddress } from '../../api/utils'
 import { TOKEN_QUERY, TOKEN_ALLOWANCE_QUERY } from '../../graphql/queries'
 import DefaultRSVP from './RSVP'
 import DefaultApprove from './Approve'
@@ -117,17 +116,6 @@ class EventCTA extends Component {
     } = this.props
     if (!myParticipantEntry) {
       if (participants.length < participantLimit) {
-        if (isEmptyAddress(tokenAddress)) {
-          return this._renderActiveRsvp({
-            myParticipantEntry,
-            tokenAddress,
-            address,
-            deposit,
-            participants,
-            participantLimit,
-            isAllowed: true
-          })
-        }
         return (
           <SafeQuery
             query={TOKEN_ALLOWANCE_QUERY}
@@ -204,23 +192,19 @@ class EventCTA extends Component {
             },
             loading
           }) => {
-            const isToken =
-              !isEmptyAddress(tokenAddress) || tokenAddress !== null
             return (
               <>
-                {isToken ? (
-                  <Approve
-                    tokenAddress={tokenAddress}
-                    address={address}
-                    deposit={deposit}
-                    decodedDeposit={decodedDeposit}
-                    decimals={decimals}
-                    balance={balance}
-                    isAllowed={isAllowed}
-                    hasBalance={hasBalance}
-                    refetch={refetch}
-                  />
-                ) : null}
+                <Approve
+                  tokenAddress={tokenAddress}
+                  address={address}
+                  deposit={deposit}
+                  decodedDeposit={decodedDeposit}
+                  decimals={decimals}
+                  balance={balance}
+                  isAllowed={isAllowed}
+                  hasBalance={hasBalance}
+                  refetch={refetch}
+                />
                 <RSVP
                   tokenAddress={tokenAddress}
                   address={address}
@@ -233,7 +217,6 @@ class EventCTA extends Component {
             )
           }}
         </SafeQuery>
-
         <CTAInfo>
           <strong>Kickback rules:</strong>
           <ul>

--- a/src/components/SingleEvent/RSVP.js
+++ b/src/components/SingleEvent/RSVP.js
@@ -7,7 +7,7 @@ import { Going } from './Status'
 import Button from '../Forms/Button'
 import Currency from './Currency'
 import styled from 'react-emotion'
-import { EMPTY_ADDRESS } from '../../api/utils'
+import { isEmptyAddress } from '../../api/utils'
 
 const RSVPText = styled(`span`)`
   margin-right: 0.5em;
@@ -60,10 +60,10 @@ const RSVP = ({
       </ChainMutation>
     )
   }
-  if (tokenAddress !== EMPTY_ADDRESS) {
+  if (!isEmptyAddress(tokenAddress)) {
     return isAllowed && hasBalance ? <ReadyButton /> : <NotReadyButton />
   } else {
-    return isAllowed ? <ReadyButton /> : <NotReadyButton />
+    return hasBalance ? <ReadyButton /> : <NotReadyButton />
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I've fixed a couple of inconsistencies on the RSVP button when using ETH

## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- Hides Approve button for ETH by fixing isToken check
- Disables RSVP button if ether balance is too low
- Adds handling for ETH in getTokenAllowance (returns `{balance: balance, allowance: balance}`)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I've checked the appearance for when I have enough / not enough ETH to ensure that it displays correctly. Also for another token to ensure that they are unaffected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.