### PR TITLE
Refactored getWeb3 to split it up into smaller functions

### DIFF
--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -170,7 +170,7 @@ const getWeb3 = lazyAsync(async () => {
       web3 = connectToInjectedWeb3()
     } catch {
       try {
-        web3 = connectToLocalNode()
+        web3 = await connectToLocalNode()
       } catch {
         try {
           web3 = connectToCloudNode()

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -174,6 +174,7 @@ const getWeb3 = lazyAsync(async () => {
       } catch {
         try {
           web3 = connectToCloudNode()
+          networkState.readOnly = true
         } catch {
           networkState.allGood = false
           throw new Error('Error setting up web3')

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -93,6 +93,65 @@ const getNetworkId = async web3 => {
   }
 }
 
+const connectToInjectedWeb3 = () => {
+  let web3
+  if (window.ethereum) {
+    web3 = new Web3(window.ethereum)
+  } else if (window.web3 && window.web3.currentProvider) {
+    web3 = new Web3(window.web3.currentProvider)
+    networkState.readOnly = false
+  } else {
+    throw new Error('No web3 injected from browser')
+  }
+  return web3
+}
+
+const connectToLocalNode = lazyAsync(async () => {
+  const url = 'http://localhost:8545'
+  let web3
+
+  try {
+    await fetch(url)
+    web3 = new Web3(new Web3.providers.HttpProvider(url))
+  } catch (error) {
+    if (
+      error.readyState === 4 &&
+      (error.status === 400 || error.status === 200)
+    ) {
+      web3 = new Web3(new Web3.providers.HttpProvider(url))
+    }
+  }
+
+  if (web3) {
+    console.log('Success: Local node active')
+    return web3
+  } else {
+    throw new Error("Couldn't connect to local node")
+  }
+})
+
+const connectToCloudNode = () => {
+  const web3 = new Web3(getNetworkProviderUrl(networkState.expectedNetworkId))
+
+  if (web3) {
+    console.log('Success: Cloud node active')
+    return web3
+  } else {
+    throw new Error("Couldn't connect to cloud node")
+  }
+}
+
+const pollForBlocks = web3 => {
+  setInterval(async () => {
+    try {
+      const block = await web3.eth.getBlock('latest')
+      events.emit(NEW_BLOCK, block)
+    } catch (__) {
+      /* nothing to do */
+    }
+  }, 10000)
+}
+
 const getWeb3 = lazyAsync(async () => {
   let web3
 
@@ -107,35 +166,17 @@ const getWeb3 = lazyAsync(async () => {
     networkState.expectedNetworkId = expectedNetworkId
     networkState.expectedNetworkName = expectedNetworkName
 
-    if (window.ethereum) {
-      web3 = new Web3(window.ethereum)
-    } else if (window.web3 && window.web3.currentProvider) {
-      web3 = new Web3(window.web3.currentProvider)
-      networkState.readOnly = false
-    } else {
-      //local node
-      const url = 'http://localhost:8545'
-
+    try {
+      web3 = connectToInjectedWeb3()
+    } catch {
       try {
-        await fetch(url)
-        localEndpoint = true
-        web3 = new Web3(new Web3.providers.HttpProvider(url))
-      } catch (error) {
-        if (
-          error.readyState === 4 &&
-          (error.status === 400 || error.status === 200)
-        ) {
-          localEndpoint = true
-          web3 = new Web3(new Web3.providers.HttpProvider(url))
-        } else {
-          web3 = new Web3(getNetworkProviderUrl(networkState.expectedNetworkId))
-          networkState.readOnly = true
-        }
-      } finally {
-        if (web3 && localEndpoint) {
-          console.log('Success: Local node active')
-        } else if (web3) {
-          console.log('Success: Cloud node active')
+        web3 = connectToLocalNode()
+      } catch {
+        try {
+          web3 = connectToCloudNode()
+        } catch {
+          networkState.allGood = false
+          throw new Error('Error setting up web3')
         }
       }
     }
@@ -148,21 +189,8 @@ const getWeb3 = lazyAsync(async () => {
       networkState.wrongNetwork = true
       networkState.allGood = false
     }
-    // if web3 not set then something failed
-    if (!web3) {
-      networkState.allGood = false
-      throw new Error('Error setting up web3')
-    }
 
-    // poll for blocks
-    setInterval(async () => {
-      try {
-        const block = await web3.eth.getBlock('latest')
-        events.emit(NEW_BLOCK, block)
-      } catch (__) {
-        /* nothing to do */
-      }
-    }, 10000)
+    pollForBlocks(web3)
   } catch (err) {
     console.warn(err)
     web3 = null
@@ -179,8 +207,7 @@ export const getWeb3Read = lazyAsync(async () => {
     // If browser's web3 is on correct network then use that
     return getWeb3()
   }
-  const { expectedNetworkId } = await getExpectedNetworkId()
-  return new Web3(getNetworkProviderUrl(expectedNetworkId))
+  return connectToCloudNode()
 })
 
 export async function getDeployerAddress() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I felt the `getWeb3` function was juggling too many things so I've split each connection type off into a separate function.

`getWeb3` is now just a bunch of try catch blocks trying each method in order which (imo) is more readable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I've tested connecting with each type of web3 and they all still work fine.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.