### PR TITLE
Auto sign-in

### DIFF
--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -163,6 +163,7 @@ export const updateNetwork = async web3 => {
 
   // update global state with current network state
   updateGlobalState()
+  return networkState
 }
 
 export const getWeb3Read = async () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Currently leaving the page will sign out the user, requiring them to press the "connect to wallet" button to log in again when they next visit kickback. This also happens with opening an event in a new tab or refresh.

This PR alters GlobalState setup to automatically sign in if a wallet has previously been set.

## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- setUpWallet now takes networkId as a parameter to avoid a race condition with loading the correct networkState
- setUpWallet now takes a `dontForceSetUp` parameter to avoid overwhelming user on page load if they haven't set a wallet previously.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I've tested refreshing the page with Metamask and Authereum to make sure that I'm correctly logged in without needing to do so manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.