### PR TITLE
Add dummy response

### DIFF
--- a/src/api/resolvers/tokenResolvers.js
+++ b/src/api/resolvers/tokenResolvers.js
@@ -361,6 +361,7 @@ const resolvers = {
           return { name, symbol, decimals }
         } catch (err) {
           throw new Error(`Failed to get Token`)
+          return { name: null, symbol: null, decimals: 18 }
         }
       }
     }


### PR DESCRIPTION
## Description

Add dummy response when Remote node api endpoint throws an error.


## How Has This Been Tested?

You can replicate the same issue on your local machine by removing `INFURA_KEY` from  `src/config/env.json`.

