### PR TITLE
Fix problem of keep appending resize flag

### DIFF
--- a/src/components/SingleEvent/Admin/EventEdit.js
+++ b/src/components/SingleEvent/Admin/EventEdit.js
@@ -7,7 +7,6 @@ import Loader from '../../Loader'
 import PartyForm from './PartyForm'
 import WarningBox from '../../WarningBox'
 import SafeQuery from '../../SafeQuery'
-import { getPartyImage } from '../../../utils/parties'
 
 function UpdatePartyMetaComponent({ address }) {
   return (
@@ -29,7 +28,6 @@ function UpdatePartyMetaComponent({ address }) {
             )
           }
         }
-        party.headerImg = getPartyImage(party.headerImg)
         return (
           <>
             <PartyForm

--- a/src/components/SingleEvent/Admin/PartyForm.js
+++ b/src/components/SingleEvent/Admin/PartyForm.js
@@ -14,6 +14,7 @@ import { Link } from 'react-router-dom'
 import Dropdown from 'react-dropdown'
 import 'react-dropdown/style.css'
 import { isAddress } from 'web3-utils'
+import { getPartyImageLarge } from '../../../utils/parties'
 
 import {
   getDayAndTimeFromDate,
@@ -134,7 +135,7 @@ const DropZoneWrapper = styled('div')`
 
 const UploadedImage = ({ src, text }) => (
   <ImageWrapper text={text}>
-    <img alt="event" src={src} />
+    <img alt="event" src={getPartyImageLarge(src)} />
   </ImageWrapper>
 )
 

--- a/src/components/SingleEvent/ParticipantTableList.js
+++ b/src/components/SingleEvent/ParticipantTableList.js
@@ -265,7 +265,8 @@ class SingleEventWrapper extends Component {
                           100
                         }
                       />
-                      {participants.length === lastParticipant.index ? null : (
+                      {!lastParticipant ||
+                      participants.length === lastParticipant.index ? null : (
                         <Mismatched>
                           The total participants ({participants.length}) does
                           not match with participant index (
@@ -315,7 +316,7 @@ class SingleEventWrapper extends Component {
                               .filter(
                                 filterParticipants(selectedFilter, search)
                               )
-                              .map((participant, idx) => {
+                              .map(participant => {
                                 const { status } = participant
                                 const withdrawn =
                                   status === PARTICIPANT_STATUS.WITHDRAWN_PAYOUT

--- a/src/routes/SingleEventAdmin.js
+++ b/src/routes/SingleEventAdmin.js
@@ -14,7 +14,6 @@ import SafeQuery from '../components/SafeQuery'
 import { GlobalConsumer } from '../GlobalState'
 import EventEdit from '../components/SingleEvent/Admin/EventEdit'
 import colours from '../colours'
-import { getPartyImageLarge } from '../utils/parties'
 
 const { primary500, primary400, primary300, primary200 } = colours
 

--- a/src/routes/SingleEventAdmin.js
+++ b/src/routes/SingleEventAdmin.js
@@ -130,7 +130,6 @@ class SingleEvent extends Component {
                       </WarningBox>
                     )
                   }
-                  party.headerImg = getPartyImageLarge(party.headerImg)
                   return (
                     <SingleEventAdminContainer>
                       <TabNavigation>

--- a/src/utils/parties.js
+++ b/src/utils/parties.js
@@ -59,24 +59,19 @@ export const filterParticipants = (selectedFilter, search) => participant => {
   )
 }
 
-export const getPartyImage = img => {
+export const getPartyImage = (img, size = 500) => {
+  const resizedImag = `image/upload/fl_lossy,f_auto,c_scale,w_${size},dpr_auto/`
   if (img) {
-    return img.replace(
-      'image/upload/',
-      `image/upload/fl_lossy,f_auto,c_scale,w_500,dpr_auto/`
-    )
+    if (img.match(resizedImag)) {
+      return img
+    } else {
+      return img.replace('image/upload/', resizedImag)
+    }
   } else {
     return 'https://placeimg.com/640/480/tech'
   }
 }
 
 export const getPartyImageLarge = img => {
-  if (img) {
-    return img.replace(
-      'image/upload/',
-      `image/upload/fl_lossy,f_auto,c_scale,w_800,dpr_auto/`
-    )
-  } else {
-    return 'https://placeimg.com/640/480/tech'
-  }
+  return getPartyImage(img, 800)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

None

## Description

Admin page kept having issues updating page event.
It turns out that it kept appending `fl_lossy,f_auto,c_scale,w_500,dpr_auto/` to ImageUrl.

## List of features added/changed

- Do not override party.imageUrl if in admin (as we are going to update) 
- Change `getImage` not to replace if the image url is already optimised

## How Has This Been Tested?

Manually in localhost

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.