### PR TITLE
Adds Meety checkin returning the list of the checked-in participants

### DIFF
--- a/src/components/SingleEvent/Admin/MeetyCheckIn.js
+++ b/src/components/SingleEvent/Admin/MeetyCheckIn.js
@@ -1,0 +1,94 @@
+import React, { useState } from 'react'
+import styled from '@emotion/styled'
+
+import Button from '../../Forms/Button'
+import TextInput from '../../Forms/TextInput'
+import Label from '../../Forms/Label'
+
+const Section = styled('section')`
+  margin-bottom: 40px;
+`
+
+const EventIdInputContainer = styled('div')`
+  display: flex;
+  margin-bottom: 20px;
+`
+
+const EventIdInput = styled(TextInput)`
+  margin: 0;
+  margin-right: 20px;
+`
+
+const POAPList = styled('ul')`
+  margin-left: 2em;
+`
+
+export default function MeetyCheckIn({ party, userAddress }) {
+  const [meetyId, setMeetyId] = useState('')
+  const [checkedInParticipants, setCheckedInParticipants] = React.useState([])
+  const [isRunning, setIsRunning] = useState(false)
+
+  const loadMeetyUser = async () => {
+    const response = await fetch(
+      `https://meety-backend.herokuapp.com/organizer/${userAddress.toLowerCase()}/events/${meetyId}/checkin`
+    )
+      .then(res => res.json())
+      .catch(err => console.log(err))
+    const participants = response.participants
+    setCheckedInParticipants(participants)
+  }
+
+  return (
+    <>
+      <Section>
+        <Label>Automatic Meety check in (experimental)</Label>
+        <p>
+          If you are using Meety Checkpoints, then you can check in your
+          attendees automatically.
+        </p>
+        <p>
+          Just enter your Meety event ID here so that it matches what is shown
+          here and Kickback will mark users who solved the minimum number of
+          required quizzes in minimum number of required checkpoint as
+          attendees.
+        </p>
+      </Section>
+      <Section>
+        <Label>Check in</Label>
+        <p>Enter your event ID and click below to check in your attendees.</p>
+
+        <EventIdInputContainer>
+          <EventIdInput
+            onChangeText={value => setMeetyId(value)}
+            placeholder="Meety Event ID"
+            type="text"
+          />
+        </EventIdInputContainer>
+        <Button
+          disabled={checkedInParticipants.length !== 0}
+          onClick={() => loadMeetyUser()}
+        >
+          Load Meety users
+        </Button>
+        <Button
+          disabled={isRunning || checkedInParticipants.length === 0}
+          onClick={() => setIsRunning(true)}
+        >
+          Mark Check In
+        </Button>
+      </Section>
+      <Section>
+        {isRunning ? <span>Auto checking in....</span> : ''}
+        <POAPList>
+          {checkedInParticipants.map((a, i) => {
+            return (
+              <li key={i}>
+                {a.user.username} {a.user.address.slice(0, 4)}...
+              </li>
+            )
+          })}
+        </POAPList>
+      </Section>
+    </>
+  )
+}

--- a/src/routes/SingleEventAdmin.js
+++ b/src/routes/SingleEventAdmin.js
@@ -6,6 +6,7 @@ import { ReactComponent as DefaultBackArrow } from '../components/svg/arrowBack.
 
 import ParticipantTableList from '../components/SingleEvent/ParticipantTableList'
 import CheckIn from '../components/SingleEvent/Admin/CheckIn'
+import MeetyCheckIn from '../components/SingleEvent/Admin/MeetyCheckIn'
 import SmartContractFunctions from '../components/SingleEvent/Admin/SmartContractFunctions'
 import WarningBox from '../components/WarningBox'
 import { PARTY_QUERY } from '../graphql/queries'
@@ -147,6 +148,14 @@ class SingleEvent extends Component {
                           POAP Check in
                         </ToggleLink>
                         <ToggleLink
+                          active={
+                            pathname === `/event/${address}/admin/meety/checkin`
+                          }
+                          to={`/event/${address}/admin/meety/checkin`}
+                        >
+                          Meety Check in
+                        </ToggleLink>
+                        <ToggleLink
                           active={pathname === `/event/${address}/admin/edit`}
                           to={`/event/${address}/admin/edit`}
                         >
@@ -174,6 +183,16 @@ class SingleEvent extends Component {
                           path={`/event/${address}/admin/checkin`}
                           exact
                           render={() => <CheckIn party={party} />}
+                        />
+                        <Route
+                          path={`/event/${address}/admin/meety/checkin`}
+                          exact
+                          render={() => (
+                            <MeetyCheckIn
+                              party={party}
+                              userAddress={userAddress}
+                            />
+                          )}
                         />
                         <Route
                           path={`/event/${address}/admin/edit`}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
### Meety Auto Checkin Integration
## Issue number
<!--- If there is an associated github issues, please specify here -->
https://explorer.bounties.network/bounty/3935

## Description
<!--- Describe your changes in detail -->
Adds a tab in Admin Panel to perform auto check-in for Meety events.

Admins can enter a Meety event id and then automatically check in all addresses which have correctly solved quizzes for that event.

## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Renamed "Check in" to "POAP Check in"
- Adds "Meety Check in" tab to admin panel
- Adds a "Load Meety User" button to fetch all the participants who have checked in using Meety app

### List of features needed
- Mark check-in is not tested as it needs a dummy event

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with a participant in Event which I have made admin to, have him solved all quizzes and can see his name on the checked-in list

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/34746546/80909159-d25f2f00-8d43-11ea-93ff-a5f1df013e00.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My code implements all the required features.